### PR TITLE
Fix failed payment page not auto reditect problem

### DIFF
--- a/pp-content/themes/gateway/vercel/views/failed-ui.php
+++ b/pp-content/themes/gateway/vercel/views/failed-ui.php
@@ -248,9 +248,6 @@
     ?>
             <script>
                 document.addEventListener('DOMContentLoaded', function() {
-                    // Show the success page (in case it was hidden)
-                    document.getElementById('success-page').style.display = 'block';
-                    
                     // Countdown functionality
                     let countdown = 4;
                     const countdownElement = document.getElementById('countdown');


### PR DESCRIPTION
## Fix: Auto-redirect issue on failed payment page

### Problem
The failed payment page was trying to show a non-existent 'success-page' element, causing JavaScript errors that broke the countdown functionality for auto-redirect.

### Solution
- Removed the incorrect line that referenced 'success-page' element
- This allows the countdown timer to work properly
- Failed payments now auto-redirect as expected after the timeout

### Files Changed
- `pp-content/themes/gateway/vercel/views/failed-ui.php`

### Testing
- Countdown functionality now works without JavaScript errors
- Auto-redirect after 4 seconds on failed payment pages (if auto redirect enabled from admin panel)