### PR TITLE
Fix Binance Pay Merchant payment method

### DIFF
--- a/pp-content/plugins/payment-gateway/binance-merchant-api/binance-merchant-api-class.php
+++ b/pp-content/plugins/payment-gateway/binance-merchant-api/binance-merchant-api-class.php
@@ -1,8 +1,8 @@
 <?php
 $plugin_meta = [
     'Plugin Name'       => 'Binance Merchant Api',
-    'Description'       => 'Accept Binance Merchant Api payments directly from customers. Perfect for freelancers and small businesses.',
-    'Version'           => '1.0.0',
+    'Description'       => 'Accept Binance Merchant API payments using the latest Binance Pay Order Create v3 endpoint.',
+    'Version'           => '1.1.0',
     'Author'            => 'PipraPay',
     'Author URI'        => 'https://piprapay.com/',
     'License'           => 'GPL-2.0+',

--- a/pp-content/plugins/payment-gateway/binance-merchant-api/readme.txt
+++ b/pp-content/plugins/payment-gateway/binance-merchant-api/readme.txt
@@ -10,15 +10,20 @@ License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
 == Description ==
 
-**Binance Merchant Api** is a payment gateway plugin for PipraPay that allows users to accept payments via Binance Merchant Api accounts. Designed for small sellers and individuals.
+**Binance Merchant Api** is a payment gateway plugin for PipraPay that allows users to accept payments via Binance Pay merchant accounts. Designed for small sellers and individuals.
 
 **Key Features:**
-
-
-**Why Use Binance Merchant Api?**
-
+* Uses Binance Pay **Order Create v3** endpoint with automatic redirect to the hosted checkout.
+* Verifies payments through the Binance Pay **Order Query v2** API before closing an order inside PipraPay.
+* Supports Binance terminal types (WEB, WAP, APP, MINI_PROGRAM) plus optional sub-merchant IDs for channel partners.
+* Pass-through metadata keeps the original PipraPay payment ID attached to every Binance Pay transaction.
 
 == Changelog ==
+
+= 1.1.0 =
+* Switch create requests to `/binancepay/openapi/v3/order` per the latest Binance documentation.
+* Query using `/binancepay/openapi/v2/order/query` and rely on `passThroughInfo` for reliable payment reconciliation.
+* Added admin controls for terminal type and optional sub-merchant IDs.
 
 = 1.0.0 =
 * Initial release

--- a/pp-content/plugins/payment-gateway/binance-merchant-api/views/admin-ui.php
+++ b/pp-content/plugins/payment-gateway/binance-merchant-api/views/admin-ui.php
@@ -180,6 +180,44 @@
                     <div class="text-secondary mt-2"> </div>
                   </div>
                 </div>
+
+                <div class="row mb-4">
+                  <div class="col-sm-6">
+                    <label for="terminal_type" class="col-sm-12 col-form-label form-label">Terminal type</label>
+                    <div class="input-group">
+                        <?php
+                            $terminalType = strtoupper($settings['terminal_type'] ?? 'WEB');
+                            $terminalOptions = [
+                                'WEB' => 'WEB (desktop browser)',
+                                'WAP' => 'WAP (mobile browser)',
+                                'APP' => 'APP (native application)',
+                                'MINI_PROGRAM' => 'MINI_PROGRAM (Binance mini program)',
+                                'OTHERS' => 'OTHERS'
+                            ];
+                        ?>
+                        <select class="form-control" name="terminal_type" id="terminal_type">
+                            <?php foreach ($terminalOptions as $value => $label): ?>
+                                <option value="<?= $value ?>" <?= ($terminalType === $value) ? 'selected' : '' ?>>
+                                    <?= htmlspecialchars($label) ?>
+                                </option>
+                            <?php endforeach; ?>
+                        </select>
+                    </div>
+                    <div class="text-secondary mt-2">
+                        Matches <code>env.terminalType</code> in <a href="https://developers.binance.com/docs/binance-pay/api-order-create-v3" target="_blank" rel="noopener noreferrer">Binance Pay Order Create v3</a>.
+                    </div>
+                  </div>
+
+                  <div class="col-sm-6">
+                    <label for="sub_merchant_id" class="col-sm-12 col-form-label form-label">Sub-merchant ID (optional)</label>
+                    <div class="input-group">
+                        <input type="text" class="form-control" name="sub_merchant_id" id="sub_merchant_id" value="<?= htmlspecialchars($settings['sub_merchant_id'] ?? '') ?>">
+                    </div>
+                    <div class="text-secondary mt-2">
+                        Required only if Binance Pay classifies your account as a channel partner.
+                    </div>
+                  </div>
+                </div>
             </div>
             <!-- End Body -->
           </div>


### PR DESCRIPTION
- Switch create requests to `/binancepay/openapi/v3/order` per the latest Binance documentation.
- Query using `/binancepay/openapi/v2/order/query` and rely on `passThroughInfo` for reliable payment reconciliation.
- Added admin controls for terminal type and optional sub-merchant IDs.
- Supports Binance terminal types (WEB, WAP, APP, MINI_PROGRAM) plus optional sub-merchant IDs for channel partners.
- Pass-through metadata keeps the original PipraPay payment ID attached to every Binance Pay transaction.
- Show QR on the payment page.
- Minor bug fixed and improve stability.

**Documentation:**
* Binance Pay Order Create v3 – https://developers.binance.com/docs/binance-pay/api-order-create-v3

**Tested with read payment flow and real merchant payment.**